### PR TITLE
Android rework picture request state tests

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
@@ -99,9 +99,8 @@ class PictureCaptureRequest {
       return;
     }
 
-    final PictureCaptureRequestState oldState = state;
     state = newState;
-    onStateChange(oldState);
+    onStateChange(newState);
   }
 
   public boolean isFinished() {
@@ -152,8 +151,8 @@ class PictureCaptureRequest {
   }
 
   /** Handle new state changes. */
-  private void onStateChange(PictureCaptureRequestState oldState) {
-    switch (state) {
+  private void onStateChange(PictureCaptureRequestState newState) {
+    switch (newState) {
       case STATE_CAPTURING:
       case STATE_WAITING_FOCUS:
       case STATE_WAITING_PRECAPTURE_START:

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
@@ -27,7 +27,7 @@ class PictureCaptureRequest {
    * This is the output file for the curent capture. The file is created in Camera and passed here
    * as reference to it.
    */
-  final File mFile;
+  final File file;
 
   /** Dart method chanel result. */
   private final MethodChannel.Result result;
@@ -54,25 +54,29 @@ class PictureCaptureRequest {
    * Constructor to create a picture capture request.
    *
    * @param result
-   * @param mFile
+   * @param file
    */
   public PictureCaptureRequest(
-      MethodChannel.Result result, File mFile, DartMessenger dartMessenger) {
-    this.result = result;
-    this.timeoutHandler = new TimeoutHandler();
-    this.mFile = mFile;
-    this.dartMessenger = dartMessenger;
+      MethodChannel.Result result,
+      File file,
+      DartMessenger dartMessenger) {
+    this(
+        result,
+        file,
+        dartMessenger,
+        new TimeoutHandler()
+    );
   }
 
   /** Constructor for unit tests where we can mock the timeout handler */
   public PictureCaptureRequest(
       MethodChannel.Result result,
-      File mFile,
+      File file,
       DartMessenger dartMessenger,
       TimeoutHandler timeoutHandler) {
     this.result = result;
     this.timeoutHandler = timeoutHandler;
-    this.mFile = mFile;
+    this.file = file;
     this.dartMessenger = dartMessenger;
   }
 

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
@@ -19,7 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
+@RunWith(RobolectricTestRunner.class)
 public class DartMessengerTest {
   /** A {@link BinaryMessenger} implementation that does nothing but save its messages. */
   private static class FakeBinaryMessenger implements BinaryMessenger {

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.1
 
-* Update platform_plugin_interface version requirement.
+- Update platform_plugin_interface version requirement.
 
 ## 2.0.0
 


### PR DESCRIPTION
Added the test cases below to improve the test coverage of the `PictureCaptureRequest` class:

- Test that the `setState` method sends an error event when the current state equals `STATE_FINISHED`;
- Test that the `finish` method returns when the current state equals `STATE_ERROR`;
- Test that the `error` method returns when the current state equals `STATE_ERROR`;

I also removed the `oldState` parameter from the `PictureCaptureRequest.onStateChange` method since it was not used and replaced it with the `newState` parameter which in my opinion makes the method easier to understand (please let me know if you don't agree).
