### PR TITLE
Fix NRE when calling setExposureOffset

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -1240,7 +1240,7 @@ public class Camera {
 
     // Refresh capture session
     refreshPreviewCaptureSession(
-        () -> result.success(null),
+        () -> result.success(offset),
         (code, message) ->
             result.error("setExposureModeFailed", "Could not set flash mode.", null));
   }


### PR DESCRIPTION
Fixes a Null Reference Exception when calling the `setExposureOffset` method.