### PR TITLE
Android rework extract capture callback

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
@@ -1,0 +1,120 @@
+package io.flutter.plugins.camera;
+
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CameraCaptureSession.CaptureCallback;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.CaptureResult;
+import android.hardware.camera2.TotalCaptureResult;
+import androidx.annotation.NonNull;
+
+class CameraCaptureCallback extends CaptureCallback {
+  interface CameraCaptureStateListener {
+    void onConverged();
+    void onPrecapture();
+    void onPrecaptureTimeout();
+  }
+
+  private final CameraCaptureStateListener cameraStateListener;
+
+  private CameraState cameraState;
+  private PictureCaptureRequest pictureCaptureRequest;
+
+  public static CameraCaptureCallback create(
+      @NonNull CameraCaptureStateListener cameraStateListener) {
+    return new CameraCaptureCallback(cameraStateListener);
+  }
+
+  private CameraCaptureCallback(
+      @NonNull CameraCaptureStateListener cameraStateListener) {
+    cameraState = CameraState.STATE_PREVIEW;
+    this.cameraStateListener = cameraStateListener;
+    this.pictureCaptureRequest = pictureCaptureRequest;
+  }
+
+  public CameraState getCameraState() {
+    return cameraState;
+  }
+
+  public void setCameraState(@NonNull CameraState state) {
+    cameraState = state;
+
+    if (pictureCaptureRequest != null && state == CameraState.STATE_WAITING_PRECAPTURE_DONE) {
+      pictureCaptureRequest.setState(
+          PictureCaptureRequestState.STATE_WAITING_PRECAPTURE_DONE);
+    }
+  }
+
+  public void setPictureCaptureRequest(@NonNull PictureCaptureRequest pictureCaptureRequest) {
+    this.pictureCaptureRequest = pictureCaptureRequest;
+  }
+
+  private void process(CaptureResult result) {
+    Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
+    Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
+
+    switch (cameraState) {
+      case STATE_PREVIEW:
+      {
+        // We have nothing to do when the camera preview is working normally.
+        break;
+      }
+      case STATE_WAITING_FOCUS:
+      {
+        if (afState == null) {
+          return;
+        } else if (afState == CaptureRequest.CONTROL_AF_STATE_PASSIVE_SCAN
+            || afState == CaptureRequest.CONTROL_AF_STATE_FOCUSED_LOCKED
+            || afState == CaptureRequest.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED) {
+          // CONTROL_AE_STATE can be null on some devices
+
+          if (aeState == null || aeState == CaptureRequest.CONTROL_AE_STATE_CONVERGED) {
+            cameraStateListener.onConverged();
+          } else {
+            cameraStateListener.onPrecapture();
+          }
+        }
+        break;
+      }
+
+      case STATE_WAITING_PRECAPTURE_START:
+      {
+        // CONTROL_AE_STATE can be null on some devices
+        if (aeState == null
+            || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED
+            || aeState == CaptureResult.CONTROL_AE_STATE_PRECAPTURE
+            || aeState == CaptureResult.CONTROL_AE_STATE_FLASH_REQUIRED) {
+          setCameraState(CameraState.STATE_WAITING_PRECAPTURE_DONE);
+        }
+        break;
+      }
+
+      case STATE_WAITING_PRECAPTURE_DONE:
+      {
+        // CONTROL_AE_STATE can be null on some devices
+        if (aeState == null || aeState != CaptureResult.CONTROL_AE_STATE_PRECAPTURE) {
+          cameraStateListener.onConverged();
+        } else if (pictureCaptureRequest != null && pictureCaptureRequest.hitPreCaptureTimeout()) {
+          // Log.i(TAG, "===> Hit precapture timeout");
+          cameraStateListener.onPrecaptureTimeout();
+        }
+        break;
+      }
+    }
+  }
+
+  @Override
+  public void onCaptureProgressed(
+      @NonNull CameraCaptureSession session,
+      @NonNull CaptureRequest request,
+      @NonNull CaptureResult partialResult) {
+    process(partialResult);
+  }
+
+  @Override
+  public void onCaptureCompleted(
+      @NonNull CameraCaptureSession session,
+      @NonNull CaptureRequest request,
+      @NonNull TotalCaptureResult result) {
+    process(result);
+  }
+}

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
@@ -41,7 +41,7 @@ class DartMessenger {
     }
   }
 
-  DartMessenger(BinaryMessenger messenger, long cameraId) {
+  public DartMessenger(BinaryMessenger messenger, long cameraId) {
     cameraChannel = new MethodChannel(messenger, "flutter.io/cameraPlugin/camera" + cameraId);
     deviceChannel = new MethodChannel(messenger, "flutter.io/cameraPlugin/device");
   }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DeviceOrientationManager.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DeviceOrientationManager.java
@@ -31,7 +31,19 @@ class DeviceOrientationManager {
   private OrientationEventListener orientationEventListener;
   private BroadcastReceiver broadcastReceiver;
 
-  public DeviceOrientationManager(
+  /**
+  * Factory method to create a device orientation manager.
+  */
+  public static DeviceOrientationManager create(
+      Activity activity,
+      DartMessenger messenger,
+      boolean isFrontFacing,
+      int sensorOrientation
+  ) {
+    return new DeviceOrientationManager(activity, messenger, isFrontFacing, sensorOrientation);
+  }
+
+  private DeviceOrientationManager(
       Activity activity, DartMessenger messenger, boolean isFrontFacing, int sensorOrientation) {
     this.activity = activity;
     this.messenger = messenger;

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
@@ -51,33 +51,33 @@ class PictureCaptureRequest {
       };
 
   /**
-   * Constructor to create a picture capture request.
+   * Factory method to create a picture capture request.
    *
    * @param result
    * @param file
    */
-  public PictureCaptureRequest(
+  static PictureCaptureRequest create(
       MethodChannel.Result result,
       File file,
       DartMessenger dartMessenger) {
-    this(
-        result,
-        file,
-        dartMessenger,
-        new TimeoutHandler()
-    );
+    return new PictureCaptureRequest(result, file, dartMessenger);
   }
 
-  /** Constructor for unit tests where we can mock the timeout handler */
-  public PictureCaptureRequest(
+  /**
+   * Private constructor to create a picture capture request.
+   *
+   * @param result
+   * @param file
+   */
+  private PictureCaptureRequest(
       MethodChannel.Result result,
       File file,
-      DartMessenger dartMessenger,
-      TimeoutHandler timeoutHandler) {
+      DartMessenger dartMessenger) {
+
     this.result = result;
-    this.timeoutHandler = timeoutHandler;
     this.file = file;
     this.dartMessenger = dartMessenger;
+    this.timeoutHandler = TimeoutHandler.create();
   }
 
   /**
@@ -184,7 +184,11 @@ class PictureCaptureRequest {
     private static final int REQUEST_TIMEOUT = 5000;
     private final Handler handler;
 
-    TimeoutHandler() {
+    public static TimeoutHandler create() {
+      return new TimeoutHandler();
+    }
+
+    private TimeoutHandler() {
       this.handler = new Handler(Looper.getMainLooper());
     }
 

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/media/MediaRecorderBuilder.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/media/MediaRecorderBuilder.java
@@ -11,30 +11,22 @@ import java.io.IOException;
 
 public class MediaRecorderBuilder {
   static class MediaRecorderFactory {
-    MediaRecorder makeMediaRecorder() {
+    static MediaRecorder create() {
       return new MediaRecorder();
     }
   }
 
   private final String outputFilePath;
   private final CamcorderProfile recordingProfile;
-  private final MediaRecorderFactory recorderFactory;
 
   private boolean enableAudio;
   private int mediaOrientation;
 
   public MediaRecorderBuilder(
       @NonNull CamcorderProfile recordingProfile, @NonNull String outputFilePath) {
-    this(recordingProfile, outputFilePath, new MediaRecorderFactory());
-  }
 
-  MediaRecorderBuilder(
-      @NonNull CamcorderProfile recordingProfile,
-      @NonNull String outputFilePath,
-      MediaRecorderFactory helper) {
-    this.outputFilePath = outputFilePath;
     this.recordingProfile = recordingProfile;
-    this.recorderFactory = helper;
+    this.outputFilePath = outputFilePath;
   }
 
   public MediaRecorderBuilder setEnableAudio(boolean enableAudio) {
@@ -48,7 +40,7 @@ public class MediaRecorderBuilder {
   }
 
   public MediaRecorder build() throws IOException {
-    MediaRecorder mediaRecorder = recorderFactory.makeMediaRecorder();
+    MediaRecorder mediaRecorder = MediaRecorderFactory.create();
 
     // There's a fixed order that mediaRecorder expects. Only change these functions accordingly.
     // You can find the specifics here: https://developer.android.com/reference/android/media/MediaRecorder.

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraTest.java
@@ -47,20 +47,29 @@ public class CameraTest {
 
       mockCamcorderProfile.videoFrameHeight = 480;
       mockCamcorderProfile.videoFrameWidth = 640;
+      when(mockCameraProperties.getLensFacing()).thenReturn(0);
+      when(mockCameraProperties.getSensorOrientation()).thenReturn(0);
       when(mockCameraProperties.getCameraName()).thenReturn(cameraName);
       when(mockCameraProperties.getControlAutoFocusAvailableModes())
           .thenReturn(new int[] {0, 1, 2});
       when(mockCameraProperties.getControlAutoExposureAvailableTargetFpsRanges()).thenReturn(null);
 
-      final Camera camera =
-          new Camera(
-              mockActivity,
-              flutterTextureMock,
-              dartMessengerMock,
-              mockCameraProperties,
-              resolutionPreset,
-              enableAudio,
-              mockDeviceOrientationManager);
+      Camera camera = null;
+      try (MockedStatic<DeviceOrientationManager> mockOrientationManagerFactory = mockStatic(DeviceOrientationManager.class)) {
+        mockOrientationManagerFactory.when(() -> DeviceOrientationManager.create(
+            mockActivity,
+            dartMessengerMock,
+            true,
+            0)).thenReturn(mockDeviceOrientationManager);
+
+        camera = new Camera(
+            mockActivity,
+            flutterTextureMock,
+            dartMessengerMock,
+            mockCameraProperties,
+            resolutionPreset,
+            enableAudio);
+      }
 
       assertNotNull("should create a camera", camera);
       assertEquals(

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/media/MediaRecorderBuilderTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/media/MediaRecorderBuilderTest.java
@@ -9,10 +9,12 @@ import static org.mockito.Mockito.*;
 
 import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
+import io.flutter.plugins.camera.media.MediaRecorderBuilder.MediaRecorderFactory;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import org.junit.Test;
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
 
 public class MediaRecorderBuilderTest {
   @Test
@@ -26,50 +28,57 @@ public class MediaRecorderBuilderTest {
   @Test
   public void build_Should_set_values_in_correct_order_When_audio_is_disabled() throws IOException {
     CamcorderProfile recorderProfile = getEmptyCamcorderProfile();
-    MediaRecorderBuilder.MediaRecorderFactory mockFactory =
-        mock(MediaRecorderBuilder.MediaRecorderFactory.class);
-    MediaRecorder mockMediaRecorder = mock(MediaRecorder.class);
     String outputFilePath = "mock_video_file_path";
     int mediaOrientation = 1;
-    MediaRecorderBuilder builder =
-        new MediaRecorderBuilder(recorderProfile, outputFilePath, mockFactory)
-            .setEnableAudio(false)
-            .setMediaOrientation(mediaOrientation);
+    MediaRecorder recorder = null;
 
-    when(mockFactory.makeMediaRecorder()).thenReturn(mockMediaRecorder);
+    try (MockedStatic<MediaRecorderFactory> mockMediaRecorderFactory = mockStatic(MediaRecorderFactory.class)) {
+      MediaRecorder mockMediaRecorder = mock(MediaRecorder.class);
+      mockMediaRecorderFactory.when(MediaRecorderFactory::create)
+          .thenReturn(mockMediaRecorder);
 
-    MediaRecorder recorder = builder.build();
+      MediaRecorderBuilder builder =
+          new MediaRecorderBuilder(recorderProfile, outputFilePath)
+              .setEnableAudio(false)
+              .setMediaOrientation(mediaOrientation);
+      recorder = builder.build();
+    }
 
-    InOrder inOrder = inOrder(recorder);
-    inOrder.verify(recorder).setVideoSource(MediaRecorder.VideoSource.SURFACE);
-    inOrder.verify(recorder).setOutputFormat(recorderProfile.fileFormat);
-    inOrder.verify(recorder).setVideoEncoder(recorderProfile.videoCodec);
-    inOrder.verify(recorder).setVideoEncodingBitRate(recorderProfile.videoBitRate);
-    inOrder.verify(recorder).setVideoFrameRate(recorderProfile.videoFrameRate);
-    inOrder
-        .verify(recorder)
-        .setVideoSize(recorderProfile.videoFrameWidth, recorderProfile.videoFrameHeight);
-    inOrder.verify(recorder).setOutputFile(outputFilePath);
-    inOrder.verify(recorder).setOrientationHint(mediaOrientation);
-    inOrder.verify(recorder).prepare();
+      InOrder inOrder = inOrder(recorder);
+      inOrder.verify(recorder).setVideoSource(MediaRecorder.VideoSource.SURFACE);
+      inOrder.verify(recorder).setOutputFormat(recorderProfile.fileFormat);
+      inOrder.verify(recorder).setVideoEncoder(recorderProfile.videoCodec);
+      inOrder.verify(recorder).setVideoEncodingBitRate(recorderProfile.videoBitRate);
+      inOrder.verify(recorder).setVideoFrameRate(recorderProfile.videoFrameRate);
+      inOrder
+          .verify(recorder)
+          .setVideoSize(recorderProfile.videoFrameWidth, recorderProfile.videoFrameHeight);
+      inOrder.verify(recorder).setOutputFile(outputFilePath);
+      inOrder.verify(recorder).setOrientationHint(mediaOrientation);
+      inOrder.verify(recorder).prepare();
   }
 
   @Test
   public void build_Should_set_values_in_correct_order_When_audio_is_enabled() throws IOException {
+    MediaRecorder recorder = null;
     CamcorderProfile recorderProfile = getEmptyCamcorderProfile();
     MediaRecorderBuilder.MediaRecorderFactory mockFactory =
         mock(MediaRecorderBuilder.MediaRecorderFactory.class);
-    MediaRecorder mockMediaRecorder = mock(MediaRecorder.class);
     String outputFilePath = "mock_video_file_path";
     int mediaOrientation = 1;
-    MediaRecorderBuilder builder =
-        new MediaRecorderBuilder(recorderProfile, outputFilePath, mockFactory)
-            .setEnableAudio(true)
-            .setMediaOrientation(mediaOrientation);
 
-    when(mockFactory.makeMediaRecorder()).thenReturn(mockMediaRecorder);
+    try (MockedStatic<MediaRecorderFactory> mockMediaRecorderFactory = mockStatic(MediaRecorderFactory.class)) {
+      MediaRecorder mockMediaRecorder = mock(MediaRecorder.class);
+      mockMediaRecorderFactory.when(MediaRecorderFactory::create)
+          .thenReturn(mockMediaRecorder);
 
-    MediaRecorder recorder = builder.build();
+      MediaRecorderBuilder builder =
+          new MediaRecorderBuilder(recorderProfile, outputFilePath)
+              .setEnableAudio(true)
+              .setMediaOrientation(mediaOrientation);
+
+      recorder = builder.build();
+    }
 
     InOrder inOrder = inOrder(recorder);
     inOrder.verify(recorder).setAudioSource(MediaRecorder.AudioSource.MIC);


### PR DESCRIPTION
Hi @acoutts,

This is my attempt to extract the `CameraCaptureSession.CaptureCallback` implementation from the `Camera` class and into its own class. This should make it a lot easier to test the logic in the `process` method since we can mock everything out now. 

Could you have a look at it and maybe see if it can be improved? Personally I feel setting the `PictureCaptureRequest` instance could be improved as it feels a bit fragile at the moment but it should work.

Anyway before I continue I would love you feedback if you'd have some time.

P.S. are you also on the Flutter community slack or Discord channels? Might be a bit easier to have a short discussion if you don't mind.